### PR TITLE
Oct-nov timesheet for p-ops

### DIFF
--- a/eng/p-ops/oct-nov-backlog.md
+++ b/eng/p-ops/oct-nov-backlog.md
@@ -1,0 +1,14 @@
+#################
+# Summary
+* Owner: P-OPS Team
+* Back Log Entry 26-Oct-Nov-2021 to 14-Nov-2021. Further timesheets will be entered weekly
+* Total: 13.5 hours
+* Overtime: 0 hours
+
+# Time Table
+| date  | start time  | end time | duration  |  note |
+|---|---|---|---|---|
+| 26-Oct-2021 | | | 1 | Initial discussion on Testnet grant proposal with Leo  |
+| 28-Oct-2021 | | | 2.5 | Harmony Testnet outage due to local network spam.  Server was locked by hetzner. Got remote access, applied new ufw rules. Verified all services are restored - Tx / uptime bot/ contract deploy/ faucet. https://harmonyone.pagerduty.com/incidents/Q2NECS1E5FTDD8 | 
+| 29-Nov-2021 | | | 2 | Testnet node stuck - https://github.com/harmony-one/harmony/issues/3917 , tried reverting binary, didn't work. restored a healthy db, synced and caught up. pager duty resolved. |
+| 01-Nov-2021 to 14-Nov-2021 | | | 8 | Testnet funding support & Validator creation support in Telegram. Debugging of testnet Issue https://github.com/harmony-one/harmony/issues/3933 |


### PR DESCRIPTION
This is backlog entry for oct-nov done by p-ops for testnet management and support
new timesheets will be submitted weekly.